### PR TITLE
Arrow improvement

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -2878,7 +2878,8 @@ function mobs:register_arrow(name, def)
 		rotate = def.rotate,
 		automatic_face_movement_dir = def.rotate
 			and (def.rotate - (pi / 180)) or false,
-
+		
+		on_activate = def.on_activate or nil,
 		on_step = def.on_step or function(self, dtime)
 
 			self.timer = self.timer + 1


### PR DESCRIPTION
Makes it possible for 'on_activate' to be used when registering arrows.
Could be used to set the velocity or textures etc. of the arrow.