### PR TITLE
Fix bad mob detection in arrow's hit_mob event

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -3050,11 +3050,7 @@ function mobs:register_arrow(name, def)
 					if self.hit_mob
 					and tostring(player) ~= self.owner_id
 					and entity ~= self.object:get_luaentity().name
-					and entity ~= "__builtin:item"
-					and entity ~= "__builtin:falling_node"
-					and entity ~= "gauges:hp_bar"
-					and entity ~= "signs:text"
-					and entity ~= "itemframes:item" then
+					and self._cmi_is_mob == true then
 
 						self.hit_mob(self, player)
 


### PR DESCRIPTION
I noticed the check whether an entity is a mob or not in the `hit_mob` event of arrows is very flimsy and relies on hardcoded entity names. Custom non-mob entities could easily get caught in the event.

Using `_cmi_is_mob` makes more sense.