### PR TITLE
Add 'after_on_activate()' call

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -2763,7 +2763,11 @@ minetest.register_entity(name, {
 	on_grown = def.on_grown,
 
 	on_activate = function(self, staticdata, dtime)
-		return mob_activate(self, staticdata, def, dtime)
+		local result = mob_activate(self, staticdata, def, dtime)
+		if def.after_on_activate then
+			return def.after_on_activate(self, staticdata, def, dtime, result)	
+		end
+		return result
 	end,
 
 	get_staticdata = function(self)

--- a/api.txt
+++ b/api.txt
@@ -113,7 +113,7 @@ Custom mob functions inside mob registry:
         'on_breed' called when two similar mobs breed, paramaters are (parent1, parent2) objects, return false to stop child from being resized and owner/tamed flags and child textures being applied.
         'on_grown' is called when a child mob has grown up, only paramater is (self).
         'do_punch' called when mob is punched with paramaters (self, hitter, time_from_last_punch, tool_capabilities, direction), return false to stop punch damage and knockback from taking place.
-
+	'after_on_activate' called after a mob is activated. This is called with parameters (self, staticdata, def, dtime, activation_result) where activation_result is whatever mob_activate() call returns. This function is called just after the activation ('mob_activate') function is called.
 
 
 Mobs can look for specific nodes as they walk and replace them to mimic eating.


### PR DESCRIPTION
This pull request adds a way to extend the `on_activate` function without making public `mob_activate()` and without totally replacing it. I understand that calling `mob_activate()` is essential for the API to work, so instead of adding a way to override it, I have added the ability to do an extra function call after `mob_activate()` has been called.

The extra `result` paramter in `api.lua` I think it is unnecessary; I left it because the original function does `return mob_activate()`, but I have seen that the function returns nothing. This can be removed and will make the code cleaner.