### PR TITLE
Expose spawn definitions in mobs.registered_spawns

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -2649,6 +2649,7 @@ end
 
 
 mobs.spawning_mobs = {}
+mobs.registered_spawns = {}
 
 -- register mob entity
 function mobs:register_mob(name, def)
@@ -2827,7 +2828,7 @@ function mobs:spawn_specific(name, nodes, neighbors, min_light, max_light,
 
 	end
 
-	minetest.register_abm({
+	local abm_def = {
 
 		label = name .. " spawning",
 		nodenames = nodes,
@@ -2943,7 +2944,26 @@ function mobs:spawn_specific(name, nodes, neighbors, min_light, max_light,
 					name, minetest.pos_to_string(pos)))
 			end
 		end
-	})
+	}
+	minetest.register_abm(abm_def)
+
+	if not mobs.registered_spawns[name] then
+		mobs.registered_spawns[name] = {}
+	end
+	local spawn_def = {
+		nodes = nodes,
+		neighbors = neighbors,
+		min_light = min_light,
+		max_light = max_light,
+		interval = interval,
+		chance = chance,
+		aoc = aoc,
+		min_height = min_height,
+		max_height = max_height,
+		day_toggle = day_toggle,
+		on_spawn = on_spawn,
+	}
+	table.insert(mobs.registered_spawns[name], spawn_def)
 end
 
 

--- a/api_new.txt
+++ b/api_new.txt
@@ -323,12 +323,24 @@ command which uses above names to make settings clearer:
        max_light = 7,
     })
 
+Each spawn_definition is a table and has all the attributes you find in
+mobs:register_spawn.
 
 For each mob that spawns with this function is a field in mobs.spawning_mobs.
 It tells if the mob should spawn or not.  Default is true.  So other mods can
 only use the API of this mod by disabling the spawning of the default mobs in
 this mod.
 
+Each spawn definition is stored in mobs.registered_spawns. The table format is:
+
+    mobs.registered_spawns = {
+        [mob_name_1] = { spawn_definition_1, spawn_definition_2, ... },
+        [mob_name_2] = { ... },
+        ...
+    }
+
+Each spawn_definition is a table and has all the attributes you find in
+mobs:register_spawn.
 
 Making Arrows
 -------------


### PR DESCRIPTION
Fixes #133.

Adds `mobs.registered_spawns` which allows mobs to learn about the spawn rules of mobs.

To learn more about this, see the changes in `api_new.txt`.