### PR TITLE
Disable fuse of exploing mobs when out of reach

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -1845,10 +1845,10 @@ local do_states = function(self, dtime)
 				mob_sound(self, self.sounds.fuse)
 --				print ("=== explosion timer started", self.explosion_timer)
 
-			-- stop timer if out of blast radius or direct line of sight
+			-- stop timer if out of reach or direct line of sight
 			elseif self.allow_fuse_reset
 			and self.v_start
-			and (dist > max(self.reach, entity_damage_radius) + 0.5
+			and (dist > self.reach
 					or not line_of_sight(self, s, p, 2)) then
 				self.v_start = false
 				self.timer = 0

--- a/api.txt
+++ b/api.txt
@@ -46,8 +46,6 @@ functions needed for the mob to work properly which contains the following:
                    in e.g. "air" or "default:water_source".
    'runaway'       if true causes animals to turn and run away when hit.
    'view_range'    how many nodes in distance the mob can see a player.
-   'reach'         how many nodes in distance a mob can attack a player while
-                   standing.
    'damage'        how many health points the mob does to a player or another
                    mob when melee attacking.
    'knock_back'    when true has mobs falling backwards when hit, the greater


### PR DESCRIPTION
The fuse disabling method for exploding mobs is pretty weird. It uses either `reach` or `entity_damage_radius`, whichever is larger. Plus 0.5. This is needlessly complicated and confusing.
I have simplified to only use `reach` for this. Much easier to handle since you can set any `reach` you want. Documentation already reflects this anyway.

With this change I managed to implement a creeper quite close to the Minecraft mob!


The `api.txt` change is just removing a duplicate.